### PR TITLE
Replace gulp-clean with del module

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ var gulp = require('gulp'),
     jshint = require('gulp-jshint'),
     uglify = require('gulp-uglify'),
     rename = require('gulp-rename'),
-    clean = require('gulp-clean'),
+    del = require('del'),
     concat = require('gulp-concat'),
     notify = require('gulp-notify'),
     cache = require('gulp-cache'),
@@ -45,9 +45,11 @@ gulp.task('scripts', function() {
     .pipe(browserSync.reload({stream:true}));
 });
 
-gulp.task('clean', function() {
-  return gulp.src(['stylesheets', 'javascripts'], {read: false})
-    .pipe(clean());
+gulp.task('clean', function(cb) {
+  del([
+    'stylesheets',
+    'javascripts'
+  ], cb);
 });
 
 gulp.task('browser-sync', ['styles', 'scripts'], function() {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp": "^3.8.7",
     "gulp-autoprefixer": "0.0.8",
     "gulp-cache": "^0.2.0",
-    "gulp-clean": "^0.3.1",
+    "del": "^1.1.1",
     "gulp-concat": "^2.3.4",
     "gulp-cssshrink": "^0.1.4",
     "gulp-jshint": "^1.8.3",


### PR DESCRIPTION
It appears that [gulp-clean](https://github.com/peter-vilja/gulp-clean) was deprecated in favor of [gulp-rimraf](https://github.com/robrich/gulp-rimraf), which was in turn deprecated [in favor of using the del module](https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md). 

Can't see as this matters much, but I noticed the deprecation warning when doing the initial `npm install` and figured it might be nice to be rid of that.
